### PR TITLE
Update engine.js

### DIFF
--- a/htdocs/js/engine.js
+++ b/htdocs/js/engine.js
@@ -1253,15 +1253,6 @@ proto.updateWaves = function horde_Engine_proto_updateWaves (elapsed) {
 
 		// Clay.io: Achievements
 		var achievementId = false;
-		switch( this.currentWaveId + 1 ) {
-			case 1:
-				achievementId = "wave1";
-				break;
-			case 5:
-				achievementId = "wave5";
-				break;
-		}
-
 		if(achievementId && !horde.achievementsGranted[achievementId]) {
 			horde.achievementsGranted[achievementId] = true; // so we don't keep sending to Clay.io
 			(new Clay.Achievement({ id: achievementId })).award();


### PR DESCRIPTION
The game triggered a non focused state when level 1 & 5 were completed due to attempted connection with Clay.io.
All the Clay.io code should be removed but I'll just post this simple edit which circumvents the issue.